### PR TITLE
fix/DEV-132578: Add exec javascript interface to support fastlink 2.0

### DIFF
--- a/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/JavaScriptChannel.java
+++ b/packages/webview_flutter/webview_flutter_android/android/src/main/java/io/flutter/plugins/webviewflutter/JavaScriptChannel.java
@@ -58,6 +58,13 @@ public class JavaScriptChannel implements Releasable {
     }
   }
 
+  // Adapter for Javascript code expecting "exec" method
+  @SuppressWarnings("unused")
+  @JavascriptInterface
+  public void exec(final String messageString, final String callBackID, final String secureId) {
+    postMessage(messageString);
+  }
+
   @Override
   public void release() {
     if (flutterApi != null) {


### PR DESCRIPTION
Our Javascript channel is named `YodleeJS`. Fastlink 2.0 requires a `YodleeJS.exec(a,b,c)` method to exist in order to post events to Android apps. See https://finapp.yodlee.orb.alkamitech.com/2.2/20211013605/finapp/js/combo?/js/mobile/native-bridge.js&/js/mobile/bridge-helper.js&/js/mobile/mobile-wrapper.js&/js/mobile/hosted-app-bootstrap.js&/js/mobile/mfa-browser.js for a really confusing justification.